### PR TITLE
Enable manual price-per-gram entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,8 @@ This repository contains a simple Tkinter-based application for generating optim
 ## Usage
 Run `python diet_app.py` and fill in the required fields. The application now stores the last entered values in `last_setup.json` inside `C:\Users\<username>\projects\diet` (or the equivalent home folder on non-Windows systems) and reloads them on startup so you do not need to re-enter data each time.
 
+### Manual Price Entry
+In the "Price Table" fields of the application you can manually enter lines of the form `fdc_id,price_per_gram`. This allows you to specify or adjust prices without using the "Add Product" helper. If the weight field is left empty when adding a product, the value in the price field is treated directly as `price_per_gram`.
+
 ## Building the USDA Database
 Use `python build_db_app.py` to open a helper application for creating `usda.db` from the USDA CSV exports. The application places the working directory in `C:\Users\<username>\projects\diet` (or the equivalent home folder on non-Windows systems) and allows you to select the CSV files via a simple GUI.

--- a/diet_app.py
+++ b/diet_app.py
@@ -83,7 +83,10 @@ class DietApp:
         self.search_results.grid(row=row, column=0, sticky="w")
         self.search_results.bind("<<ListboxSelect>>", self.on_result_select)
         row += 1
-        ttk.Label(self.left_scrollable_frame, text="Price ($) and Weight (g):").grid(row=row, column=0, sticky="w")
+        ttk.Label(
+            self.left_scrollable_frame,
+            text="Price ($) and Weight (g) (leave weight blank for price per gram):",
+        ).grid(row=row, column=0, sticky="w")
         row += 1
         pw_frame = ttk.Frame(self.left_scrollable_frame)
         pw_frame.grid(row=row, column=0, sticky="w")
@@ -243,15 +246,23 @@ class DietApp:
         if fid is None:
             messagebox.showerror("Error", "Select a product from the search results")
             return
+        price_str = self.price_entry.get().strip()
+        weight_str = self.weight_entry.get().strip()
         try:
-            price = float(self.price_entry.get())
-            weight = float(self.weight_entry.get())
-            if weight <= 0:
-                raise ValueError
+            price = float(price_str)
+            if weight_str:
+                weight = float(weight_str)
+                if weight <= 0:
+                    raise ValueError
+                price_per_gram = price / weight
+            else:
+                price_per_gram = price
         except ValueError:
-            messagebox.showerror("Error", "Enter valid price and weight")
+            messagebox.showerror(
+                "Error",
+                "Enter valid numeric price and weight (weight optional)",
+            )
             return
-        price_per_gram = price / weight
         target = self.add_table_var.get()
         widget = self.price_text if target == "all" else self.raw_price_text
         lines = [ln.strip() for ln in widget.get("1.0", tk.END).splitlines() if ln.strip()]


### PR DESCRIPTION
## Summary
- allow entering price per gram directly by leaving weight blank
- clarify UI text for the price/weight fields
- document manual price table usage in README

## Testing
- `python -m py_compile diet_app.py build_db_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68775961f78483289c0e7798ad5e6007